### PR TITLE
Remove table.

### DIFF
--- a/R/dashboard.Rmd
+++ b/R/dashboard.Rmd
@@ -120,7 +120,7 @@ Descargar datos
 Row {data-height=1000}
 -----------------------------------------------------------------------
 
-```{r}
+```{r, eval=FALSE}
 library(DT)
 
 datatable(


### PR DESCRIPTION
- The data table is failing because the data exceeds the max amount of records supported by the library.